### PR TITLE
Expose proxy object in module.exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = (context, options) => (ctx, next) => {
     })
   })
 }
-
+module.exports.proxy = proxy;
 function logger (ctx, target) {
   console.log('%s - %s %s proxy to -> %s', new Date().toISOString(), ctx.req.method, ctx.req.oldPath, url.resolve(target, ctx.req.url))
 }


### PR DESCRIPTION
One the biggest advantage of this module over other koa proxy middlewares that this uses `node-http-proxy`, which can proxy websocket connections as well: https://github.com/nodejitsu/node-http-proxy#proxying-websockets

I'm using this module to proxy requests to my frontend which uses `create-react-app`, which uses websocket connection to detect changes and reload the frontend. To be able to proxy websocket connection we need to listen to the `upgrade` event on the httpServer object, see below my example.

```
const Koa = require('koa');
const app = Koa();
const server = app.listen(3000, function(err) {
  if (err) {
    throw err;
  }
  console.log('App started on port %s', this.address().port);
});

if (process.env.NODE_ENV !== 'production') {
  // We start a proxy to the create-react-app dev server, which is running on port 3001
  app.use(proxy('/*', { target: 'http://localhost:3001', logs: true }));
  server.on('upgrade', function(req, socket, head) {
    proxy.proxy.ws(req, socket, head, {
      target: 'ws://localhost:3001'
    });
  });
}
```