### PR TITLE
fix: support multiple event listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ function setupProxyEventHandler (event) {
       eventHandler(...args)
     }
   })
+
+  return proxyEventHandlers[event]
 }
 
 /**
@@ -84,11 +86,9 @@ module.exports = (path, options) => {
         Object
           .entries(events)
           .forEach(([event, handler]) => {
-            const eventHandler = proxyEventHandlers[event]
-
-            if (eventHandler == null) {
-              setupProxyEventHandler(event)
-            }
+            const eventHandler = proxyEventHandlers[event] == null
+              ? setupProxyEventHandler(event)
+              : proxyEventHandlers[event]
 
             if (typeof eventHandler === 'object' && !eventHandler.has(middlewareId)) {
               eventHandler.set(middlewareId, handler)

--- a/index.js
+++ b/index.js
@@ -84,12 +84,14 @@ module.exports = (path, options) => {
         Object
           .entries(events)
           .forEach(([event, handler]) => {
-            if (proxyEventHandlers[event] == null) {
+            const eventHandler = proxyEventHandlers[event]
+
+            if (eventHandler == null) {
               setupProxyEventHandler(event)
             }
 
-            if (!proxyEventHandlers[event].has(middlewareId)) {
-              proxyEventHandlers[event].set(middlewareId, handler)
+            if (typeof eventHandler === 'object' && !eventHandler.has(middlewareId)) {
+              eventHandler.set(middlewareId, handler)
             }
           })
       }

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 const { URL } = require('url')
 const HttpProxy = require('http-proxy')
 const pathMatch = require('path-match')
+const { v4: uuidv4 } = require('uuid')
 
 /**
  * Constants
@@ -17,70 +18,83 @@ const route = pathMatch({
   end: false
 })
 
-let eventRegistered = false
+const REQUEST_IDENTIFIER = '__KOA_PROXIES_MIDDLEWARE_ID__'
+
+const proxyEventHandlers = {}
 
 /**
  * Koa Http Proxy Middleware
  */
-module.exports = (path, options) => (ctx, next) => {
-  // create a match function
-  const match = route(path)
-  const params = match(ctx.path)
-  if (!params) return next()
+module.exports = (path, options) => {
+  const middlewareId = uuidv4()
 
-  let opts
-  if (typeof options === 'function') {
-    opts = options.call(options, params, ctx)
-  } else {
-    opts = Object.assign({}, options)
-  }
-  // object-rest-spread is still in stage-3
-  // https://github.com/tc39/proposal-object-rest-spread
-  const { logs, rewrite, events } = opts
+  return (ctx, next) => {
+    // create a match function
+    const match = route(path)
+    const params = match(ctx.path)
+    if (!params) return next()
 
-  const httpProxyOpts = Object.keys(opts)
-    .filter(n => ['logs', 'rewrite', 'events'].indexOf(n) < 0)
-    .reduce((prev, cur) => {
-      prev[cur] = opts[cur]
-      return prev
-    }, {})
-
-  return new Promise((resolve, reject) => {
-    ctx.req.oldPath = ctx.req.url
-
-    if (typeof rewrite === 'function') {
-      ctx.req.url = rewrite(ctx.req.url, ctx)
+    let opts
+    if (typeof options === 'function') {
+      opts = options.call(options, params, ctx)
+    } else {
+      opts = Object.assign({}, options)
     }
+    // object-rest-spread is still in stage-3
+    // https://github.com/tc39/proposal-object-rest-spread
+    const { logs, rewrite, events } = opts
 
-    if (logs) {
-      typeof logs === 'function' ? logs(ctx, opts.target) : logger(ctx, opts.target)
-    }
-    if (events && typeof events === 'object' && !eventRegistered) {
-      Object.entries(events).forEach(([event, handler]) => {
-        proxy.on(event, handler)
+    const httpProxyOpts = Object.keys(opts)
+      .filter(n => ['logs', 'rewrite', 'events'].indexOf(n) < 0)
+      .reduce((prev, cur) => {
+        prev[cur] = opts[cur]
+        return prev
+      }, {})
+
+    return new Promise((resolve, reject) => {
+      ctx.req.oldPath = ctx.req.url
+
+      if (typeof rewrite === 'function') {
+        ctx.req.url = rewrite(ctx.req.url, ctx)
+      }
+
+      if (logs) {
+        typeof logs === 'function' ? logs(ctx, opts.target) : logger(ctx, opts.target)
+      }
+
+      if (events && typeof events === 'object') {
+        ctx.req[REQUEST_IDENTIFIER] = middlewareId
+
+        Object.entries(events).forEach(([event, handler]) => {
+          if (proxyEventHandlers[event] == null) {
+            proxyEventHandlers[event] = new Map()
+          }
+          if (!proxyEventHandlers[event].has(middlewareId)) {
+            proxyEventHandlers[event].set(middlewareId, handler)
+          }
+        })
+      }
+
+      // Let the promise be solved correctly after the proxy.web.
+      // The solution comes from https://github.com/nodejitsu/node-http-proxy/issues/951#issuecomment-179904134
+      ctx.res.on('close', () => {
+        reject(new Error(`Http response closed while proxying ${ctx.req.oldPath}`))
       })
-      eventRegistered = true
-    }
 
-    // Let the promise be solved correctly after the proxy.web.
-    // The solution comes from https://github.com/nodejitsu/node-http-proxy/issues/951#issuecomment-179904134
-    ctx.res.on('close', () => {
-      reject(new Error(`Http response closed while proxying ${ctx.req.oldPath}`))
-    })
+      ctx.res.on('finish', () => {
+        resolve()
+      })
 
-    ctx.res.on('finish', () => {
-      resolve()
+      proxy.web(ctx.req, ctx.res, httpProxyOpts, e => {
+        const status = {
+          ECONNREFUSED: 503,
+          ETIMEOUT: 504
+        }[e.code]
+        ctx.status = status || 500
+        resolve()
+      })
     })
-
-    proxy.web(ctx.req, ctx.res, httpProxyOpts, e => {
-      const status = {
-        ECONNREFUSED: 503,
-        ETIMEOUT: 504
-      }[e.code]
-      ctx.status = status || 500
-      resolve()
-    })
-  })
+  }
 }
 
 module.exports.proxy = proxy

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   },
   "dependencies": {
     "http-proxy": "^1.18.1",
-    "path-match": "^1.2.4"
+    "path-match": "^1.2.4",
+    "uuid": "^8.3.2"
   },
   "peerDependencies": {
     "koa": ">=2"

--- a/test/test.js
+++ b/test/test.js
@@ -252,6 +252,25 @@ describe('tests for koa proxies', () => {
     sinon.assert.calledOnce(proxyTwoResSpy)
   })
 
+  it('ignore events for middleware if they are not a valid event', async () => {
+    // spies
+    const proxyInvalidEventSpy = sinon.spy()
+
+    const proxyMiddleware = proxy('/200', {
+      target: 'http://127.0.0.1:12306',
+      changeOrigin: true,
+      logs: true,
+      events: {
+        proxyInvalid: proxyInvalidEventSpy
+      }
+    })
+
+    server = startServer(3000, proxyMiddleware)
+
+    await chai.request(server).get('/200')
+    sinon.assert.notCalled(proxyInvalidEventSpy)
+  })
+
   it('log', async () => {
     // spies
     const logSpy = sinon.spy(console, 'log')


### PR DESCRIPTION
## Purpose

To fix #65 by allowing multiple event listeners from each registered proxy middleware.

## How it works

Each middleware is given a unique id, this is passed to the request which we can then use in the proxy event listeners to call the event handler which belongs to the middleware based on this unique id.
