### PR TITLE
feat: call events.error handler from error callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,13 @@ module.exports = (path, options) => {
         resolve()
       })
 
-      proxy.web(ctx.req, ctx.res, httpProxyOpts, e => {
+      proxy.web(ctx.req, ctx.res, httpProxyOpts, (e, ...args) => {
+        const errorHandler = proxyEventHandlers.error && proxyEventHandlers.error.get(ctx.req[REQUEST_IDENTIFIER])
+
+        if (typeof errorHandler === 'function') {
+          errorHandler(e, ...args) // If this error handler sends the headers, the ctx.status setter below is ignored
+        }
+
         const status = {
           ECONNREFUSED: 503,
           ETIMEOUT: 504


### PR DESCRIPTION
Since the error event is not emitted by the underlying `http-proxy` when there is an error callback in place, add some code to manually call the error event handler if it is specified.

Fixes https://github.com/vagusX/koa-proxies/issues/69.