### PR TITLE
feat: options function return false, fix default logger

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ declare namespace KoaProxies {
     }
   }
 
-  type IKoaProxiesOptionsFunc = (params: { [key: string]: string }, ctx: Koa.Context) => IBaseKoaProxiesOptions;
+  type IKoaProxiesOptionsFunc = (params: { [key: string]: string }, ctx: Koa.Context) => IBaseKoaProxiesOptions | false;
 
   type IKoaProxiesOptions = string | IBaseKoaProxiesOptions | IKoaProxiesOptionsFunc;
 }

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ options.logs = true; // or false
 // custom log function
 options.logs = (ctx, target) {
   console.log('%s - %s %s proxy to -> %s', new Date().toISOString(), ctx.req.method, ctx.req.oldPath, new URL(ctx.req.url, target))
-} 
+}
 ```
 
 ## Usage
@@ -52,13 +52,34 @@ const app = new Koa()
 
 // middleware
 app.use(proxy('/octocat', {
-  target: 'https://api.github.com/users',    
+  target: 'https://api.github.com/users/',
   changeOrigin: true,
   agent: new httpsProxyAgent('http://1.2.3.4:88'), // if you need or just delete this line
   rewrite: path => path.replace(/^\/octocat(\/|\/\w+)?$/, '/vagusx'),
   logs: true
 }))
 ```
+The 2nd parameter `options` can be a function. It will be called with the path matching result (see [path-match](https://www.npmjs.com/package/path-match) for details) and Koa `ctx` object. You can leverage this feature to dynamically set proxy. Here is an example:
+
+```js
+// dependencies
+const Koa = require('koa')
+const proxy = require('koa-proxies')
+
+const app = new Koa()
+
+// middleware
+app.use(proxy('/octocat/:name', (params, ctx) => {
+  return {
+    target: 'https://api.github.com/',
+    changeOrigin: true,
+    rewrite: () => `/users/${params.name}`,
+    logs: true
+  }})
+)
+```
+Moreover, if the `options` function return `false`, then the proxy will be bypassed. This allows the middleware to bail out even if path matching succeeds, which could be helpful if you need complex logic to determine whether to proxy or not.
+
 
 ### Attention
 
@@ -71,7 +92,7 @@ const proxy = require('koa-proxies')
 const bodyParser = require('koa-bodyparser')
 
 app.use(proxy('/user', {
-  target: 'http://example.com',    
+  target: 'http://example.com',
   changeOrigin: true
 }))
 


### PR DESCRIPTION
This PR does several things:
- `options` function now can return `false`. This allows the middleware to bail out even if path matching succeeds, which could be helpful if you need complex logic to determine whether to proxy or not.
- Fix the default logger.  Because the proxying is done by http-proxy, Getting correct proxied url needs imitating the behavior of http-proxy. The original implementation can log false information in many cases. **BE CAUTION** that here we rely on inner implementation of [http-proxy](https://github.com/http-party/node-http-proxy/blob/master/lib/http-proxy/common.js#L33).
- Remove and simplify `object-rest-spread is still in stage-3` related code. `object-rest-spread` should be stable now.
- Fix the github API unit test.
- Docs, etc

The modification should be backward compatible.